### PR TITLE
Custom format

### DIFF
--- a/site/assets/css/GradientsStyle.css
+++ b/site/assets/css/GradientsStyle.css
@@ -122,3 +122,7 @@ body {
   color: lightgray;
   font-family: MinecraftRegular;
 }
+
+.hidden {
+  display: none;
+}

--- a/site/templates/Gradients.ejs
+++ b/site/templates/Gradients.ejs
@@ -39,8 +39,7 @@
             <div class="col-md-3" style="padding-left: 0;">
               <label for="nickname">Text</label>
               <input class="form-control" id="nickname" type="text" maxlength="100" placeholder="Your Text"
-                     value="SimplyMC" oninput="javascript: updateOutputText(event);"
-                     onchange="javascript: updateOutputText(event)">
+                     value="SimplyMC" oninput="updateOutputText(event);">
             </div>
           </div>
           <div class="row">
@@ -57,7 +56,27 @@
                 <option value='5'>/nick (&x&r&r&g&g&b&b)</option>
                 <option value='6'>console (§x§r§r§g§g§b§b)</option>
                 <option value='7'>bbcode [COLOR=#rrggbb]</option>
+                <option value='8'>custom</option>
               </select>
+            </div>
+          </div>
+          <div class="row hidden" id="customFormatWrapper">
+            <div class="col-md-3" style="padding-left: 0;">
+              <label for="customFormat">Custom Format</label>
+              <input type="text"
+                     class="form-control"
+                     id="customFormat"
+                     oninput="updateOutputText(event);">
+              <p>Placeholders:</p>
+              <ul>
+                <li>$1 - First RR hex</li>
+                <li>$2 - Second RR hex</li>
+                <li>$3 - First GG hex</li>
+                <li>$4 - Second GG hex</li>
+                <li>$5 - First BB hex</li>
+                <li>$6 - Second BB hex</li>
+                <li>$c - Character to format</li>
+              </ul>
             </div>
           </div>
           <div class="row">
@@ -79,15 +98,15 @@
           </div>
           <div class="row">
             <label for="exportPreset">Export Preset</label>
-            <button class="form-control" 
-            style="width: 125px;" 
+            <button class="form-control"
+            style="width: 125px;"
             type="button" id="exportPreset"
             onclick="copyTextToClipboard(exportPreset());">Copy Preset</button>
           </div>
           <div class="row">
             <label for="importPreset">Import Preset</label>
-            <button class="form-control" 
-            style="width: 125px;" 
+            <button class="form-control"
+            style="width: 125px;"
             type="button" id="importPreset"
             onclick="showfield('importInput')"
             >Import Preset</button>
@@ -106,7 +125,7 @@
                    onchange="updateOutputText(event); toggleColors(this.value);"
                    oninput="updateOutputText(event); toggleColors(this.value);"/>
           </div>
-          <div class="row">
+          <div class="row" id="formatSelector">
             <div id="dbold">
               <input type="checkbox" id="bold" onclick="updateOutputText(event);"/>
               <label for="bold">Bold</label>


### PR DESCRIPTION
This PR adds the ability to specify a custom format. This is useful for scenarios that aren't covered by the presets.


https://user-images.githubusercontent.com/34699884/164769828-4d0c9b6d-c7b7-4b71-9e22-0fa962601859.mp4
(ignore `undefined`, that has been fixed)


**Optimizations**
- Less document queries. (Don't query the DOM too often)
- Preset export no longer modifies the DOM.

**Improvements**
- Bold, italic, etc. options are hidden when the format does not support it.
- Preview is no longer bold, italic, etc. when the format does not support it.
- Preset import/export now supports selected and custom format.