### PR TITLE
fixes

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,26 +1,29 @@
-const {app, BrowserWindow} = require('electron')
-const ejse = require('ejs-electron')
+const { app, BrowserWindow } = require('electron');
+const ejse = require('ejs-electron');
 const path = require("path");
 
-let mainWindow
- 
+let mainWindow;
+
 // The absolute path of current this directory.
-const dataDir = path.resolve(`${__dirname}${path.sep}site`);
+const dataDir = path.join(__dirname, 'site');
 
 // Absolute path of ./templates directory.
-const templateDir = path.resolve(`${dataDir}${path.sep}templates`);
+const templateDir = path.join(dataDir, 'templates');
 
 const renderTemplate = (mainWindow, template, data = {}) => {
     // Default base data which passed to the ejs template by default.
-
     ejse.data({
-        path: `file://${templateDir}${path.sep}${template}`,
+        path: path.join(templateDir, template),
     });
-    mainWindow.loadURL(`${templateDir}${path.sep}${template}`);
+
+    // Load the template
+    mainWindow.loadFile(path.join(templateDir, template));
+
+    // Show the window after the template is loaded
+    mainWindow.webContents.on('ready-to-show', async () => mainWindow.show());
 };
 
 app.on('ready', () => {
-    mainWindow = new BrowserWindow({
-    })
-    renderTemplate(mainWindow, 'index.ejs')
-})
+    mainWindow = new BrowserWindow({ show: false });
+    renderTemplate(mainWindow, 'index.ejs');
+});

--- a/site/assets/css/style.css
+++ b/site/assets/css/style.css
@@ -14,9 +14,10 @@
   font-family: MinecraftBoldItalic;
   src: url(../fonts/MinecraftBoldItalic.otf);
 }
-body {
+html {
+  overflow: overlay;
   font-family: MinecraftRegular;
 }
-.input{
+.input {
   overflow: hidden;
 }


### PR DESCRIPTION
Use path.join instead of path.resolve and loadfile instead of loadurl, which fixes blank window, and show the window when the page has loaded to avoid flashbang